### PR TITLE
2.3.2 support - setup ss and force low, choose sane core clock

### DIFF
--- a/libad5592r.cpp
+++ b/libad5592r.cpp
@@ -7,14 +7,17 @@
 #define DEBUG       false
 
 
+#define AD5592R_SPI_CLOCK (4000000)
+
 ad5592r_t *
 ad5592r_init(ad5592r_t *obj)
 {
-    SPI.begin();
-    SPI.setDataMode(SPI_MODE1);
-    SPI.setBitOrder(MSBFIRST);
-    SPI.setClockDivider(SPI_CLOCK_DIV2);
+    pinMode(SS, OUTPUT);
+    digitalWrite(SS, LOW);
 
+    SPI.begin();
+    SPI.beginTransaction(SPISettings(AD5592R_SPI_CLOCK, MSBFIRST, SPI_MODE1)) ;
+  
     obj->supply_voltage_mV = 3300;         /* Voreingestellt Versorgungsspannung (Vdd) */
     obj->external_ref_voltage_mV = 3300;   /* Voreingestellte externe Referenzsspannung (Vref) */
 


### PR DESCRIPTION
- Update to support Arduino IDE 2.3.2
- Use new SPISettings API for SPI clock/mode configuration
- Use default 4Mhz clock as is found on all platforms
- Add missing SS configuration and initial state
- Validate and tested on Arduino UNO Minima R4 using EVAL-AD5592R-PMDZ board

![IMG_2830](https://github.com/user-attachments/assets/c464bc46-1296-402f-9996-dd8a67115733)
